### PR TITLE
Proposal for naming convention to unite SDK and BAG

### DIFF
--- a/bag_ecd/__init__.py
+++ b/bag_ecd/__init__.py
@@ -74,13 +74,13 @@ class bag_startup(metaclass=abc.ABCMeta):
     for path in GENERATORS:
         if CMPATH==BAGHOME: # We are running generators from BAG side
             if not path.endswith('_gen'):
-                print("WARN: Thou shalt name thy generators <generator_name>_gen, otherwise they will not be supported by the SyDeKick!")
+                print("WARN: Thou shalt name thy generator python package <generator_name>_gen or eventually it must be merged to TheSyDeKick Entity!")
             print("Adding %s to system path" %(path))
             sys.path.append(path)
         else: # We are running generators from SDK side
             if path not in MODULELIST:
                 if not path.endswith('_gen'):
-                    print("WARN: Thou shalt name thy generators <generator_name>_gen, otherwise they will not be supported by the SyDeKick!")
+                print("WARN: Thou shalt name thy generator pytho package <generator_name>_gen or eventually it must be merged with TheSyDeKick Entity!")
                 print("Adding %s to system path" %(path))
                 sys.path.append(path)
             else:

--- a/bag_ecd/__init__.py
+++ b/bag_ecd/__init__.py
@@ -70,18 +70,18 @@ class bag_startup(metaclass=abc.ABCMeta):
     currdir=os.getcwd()
     CMPATH=os.path.commonpath([currdir, BAGHOME])
     MODULELIST=[path.split('/')[-1] for path in sys.path] # List modules already in path
-
     for path in GENERATORS:
+        if not path.endswith('_gen'):
+            generatorname=path.split('/')[-1]
+            warning="WARN: Thou shalt name thy generator python package %s_gen or eventually it must be merged to TheSyDeKick Entity!" %(generatorname) 
+            print(warning)
+
         if CMPATH==BAGHOME: # We are running generators from BAG side
-            if not path.endswith('_gen'):
-                print("WARN: Thou shalt name thy generator python package <generator_name>_gen or eventually it must be merged to TheSyDeKick Entity!")
-            print("Adding %s to system path" %(path))
+            print("Adding %s to system path\n" %(path))
             sys.path.append(path)
         else: # We are running generators from SDK side
             if path not in MODULELIST:
-                if not path.endswith('_gen'):
-                    print("WARN: Thou shalt name thy generator python package <generator_name>_gen or eventually it must be merged with TheSyDeKick Entity!")
-                print("Adding %s to system path" %(path))
+                print("Adding %s to system path\n" %(path))
                 sys.path.append(path)
             else:
                 print("WARN: module %s already in path! Omitting!" % (path.split('/')[-1]))

--- a/bag_ecd/__init__.py
+++ b/bag_ecd/__init__.py
@@ -80,7 +80,7 @@ class bag_startup(metaclass=abc.ABCMeta):
         else: # We are running generators from SDK side
             if path not in MODULELIST:
                 if not path.endswith('_gen'):
-                print("WARN: Thou shalt name thy generator pytho package <generator_name>_gen or eventually it must be merged with TheSyDeKick Entity!")
+                    print("WARN: Thou shalt name thy generator python package <generator_name>_gen or eventually it must be merged with TheSyDeKick Entity!")
                 print("Adding %s to system path" %(path))
                 sys.path.append(path)
             else:

--- a/bag_ecd/__init__.py
+++ b/bag_ecd/__init__.py
@@ -54,30 +54,38 @@ class bag_startup(metaclass=abc.ABCMeta):
 
 
     #Appending all BAG generator python modules to system path 
-    # (only ones, with set subtraction)
-    GENERATORS=[(x[1]) for x in os.walk( BAGHOME)][0]
-    #Add automatically the files from BAGHOME
-    MODULEPATHS=[]
-    DIR=os.path.abspath(os.getcwd())
-    # This should be BAG_WORK_DIR if executed from BAG_WORK_DIR
-    DIR2=os.path.commonpath([DIR,os.environ['BAG_WORK_DIR']])
-    MODULELIST = [path.split('/')[-1] for path in sys.path]
-    for i in GENERATORS:
-        if DIR2==os.environ['BAG_WORK_DIR']:
-            if os.path.isfile(BAGHOME+"/" + i +"/" + i + "/__init__.py"):
-                MODULEPATHS.append(BAGHOME+"/" + i)
-        else:
-            # Do not add module to path if already added by TheSyDeKick
-            if i not in MODULELIST:
-                if os.path.isfile(BAGHOME+"/" + i +"/" + i + "/__init__.py"):
-                    MODULEPATHS.append(BAGHOME+"/" + i)
-
-
-    for i in list(set(MODULEPATHS)-set(sys.path)):
-        print("Adding %s to system path" %(i))
-        sys.path.append(i)
-    del i
+    # Strategy: Find all files with path "$BAG_WORK_DIR/module_name/module_name/__init__.py",
+    # append to list, set substract sys.path from GENERATORS to ensure that nothing is added
+    # twice and to ensure uniqueness
+    root=BAGHOME
+    GENERATORS=[]
+    for item in os.listdir(root):
+        if not os.path.isfile(os.path.join(root, item)):
+            if os.path.isfile(os.path.join(root, item, item, '__init__.py')):
+                GENERATORS.append(os.path.join(BAGHOME,item)) 
+    GENERATORS=list(set(GENERATORS) - set(sys.path))
     
+    # To make BAG work from SyDeKick: do not add gen to path if there is an entity with same name (this shouldn't be the case anyway)
+    # If CMPATH is not BAGHOME, then we are running from SDK.
+    currdir=os.getcwd()
+    CMPATH=os.path.commonpath([currdir, BAGHOME])
+    MODULELIST=[path.split('/')[-1] for path in sys.path] # List modules already in path
+
+    for path in GENERATORS:
+        if CMPATH==BAGHOME: # We are running generators from BAG side
+            if not path.endswith('_gen'):
+                print("WARN: Thou shalt name thy generators <generator_name>_gen, otherwise they will not be supported by the SyDeKick!")
+            print("Adding %s to system path" %(path))
+            sys.path.append(path)
+        else: # We are running generators from SDK side
+            if path not in MODULELIST:
+                if not path.endswith('_gen'):
+                    print("WARN: Thou shalt name thy generators <generator_name>_gen, otherwise they will not be supported by the SyDeKick!")
+                print("Adding %s to system path" %(path))
+                sys.path.append(path)
+            else:
+                print("WARN: module %s already in path! Omitting!" % (path.split('/')[-1]))
+
     #Default logfile. Override with initlog if you want something else
     #/tmp/TheSDK_randomstr_uname_YYYYMMDDHHMM.log
     logfile="/tmp/BAG_" + os.path.basename(tempfile.mkstemp()[1])+"_"+getpass.getuser()+"_"+time.strftime("%Y%m%d%H%M")+".log"

--- a/bag_ecd/bag_design.py
+++ b/bag_ecd/bag_design.py
@@ -29,10 +29,31 @@ class bag_design(BAG_technology_definition, bag_startup,metaclass=abc.ABCMeta):
         return os.path.dirname(os.path.realpath(__file__)) + "/"+__name__
     
     @property
+    def package(self):
+        '''
+        The name of the instance to be generated. ECD naming convention is that the package name is suffixed by _gen.
+        Thus generator package of inverter is named inverter_gen.
+        '''
+        if not hasattr(self, '_package'):
+            self._package=os.path.splitext(os.path.basename(self._classfile))[0]
+        return self._package
+    #No setter, no deleter.
+
+    @property
     def name(self):
+        '''
+        The name of the instance to be generated. ECD naming convention is that the package name is suffixed by _gen.
+        Thus generator package of inverter is named inverter_gen.
+        '''
         if not hasattr(self, '_name'):
             #_classfile is an abstract property that must be defined in the class.
-            self._name=os.path.splitext(os.path.basename(self._classfile))[0]
+            chk=re.compile(r'.*_gen')
+            test=chk.match(self.package)
+            if test:
+                self._name=(self.package).replace('_gen','')
+            else:
+                self.print_log(type='I', msg='Generator package name does not have _gen suffix, and is not ECD compliant')
+                self._name=self.package
         return self._name
     #No setter, no deleter.
     
@@ -300,6 +321,7 @@ class bag_design(BAG_technology_definition, bag_startup,metaclass=abc.ABCMeta):
         #Parameters
         bag_project=self.bag_project
         template_library=self.template_library_name
+
         cell=self.name
 
         # Import the templates
@@ -343,7 +365,7 @@ class bag_design(BAG_technology_definition, bag_startup,metaclass=abc.ABCMeta):
                        
                     for line in inputfile:
                         if re.match('from bag.design.module import Module',line):
-                            tempfile.write('from %s.schematic import schematic as %s__%s\n' %(cell,template_library,cell))
+                            tempfile.write('from %s.schematic import schematic as %s__%s\n' %(self.package,template_library,cell))
                         else:
                             pass
                             #tempfile.write(line) 

--- a/shell/rename_module.sh
+++ b/shell/rename_module.sh
@@ -8,6 +8,8 @@
 #############################################################################
 #Function to display help with -h argument and to control
 #the configuration from the command line
+set -e
+
 help_f()
 {
 SCRIPTNAME="rename_module"
@@ -65,7 +67,6 @@ sed -i "/from\s*${MODULESOURCE}/s/${MODULESOURCE}/${MODULETARGET}/g" ${MODULETAR
 sed -i "/class\s*${MODULESOURCE}/s/${MODULESOURCE}/${MODULETARGET}/g" ${MODULETARGET}/__init__.py
 sed -i "/inst\s*=\s*${MODULESOURCE}/s/${MODULESOURCE}/${MODULETARGET}/g" ${MODULETARGET}/__init__.py
 sed -i "/class\s*${MODULESOURCE}/s/${MODULESOURCE}/${MODULETARGET}/g" ${MODULETARGET}/layout.py
-sed -i "/inst\s*=\s*${MODULESOURCE}/s/${MODULESOURCE}/${MODULETARGET}/g" ${MODULETARGET}/__init__.py
 
 #3 Copy the Virtuoso templates library on other name
 mv ${MODULESOURCE}_templates ${MODULETARGET}_templates


### PR DESCRIPTION
This commit adds a warning print if the generator is named something other than <generator_name>_gen.

Also, I performed some optimization to adding the generators to path. The old version used os.walk, which goes through EVERY directory in BAG_WORK_DIR and searches for a file __init__.py. This took appoximately 30 seconds, since it went through all of the PEX, LVS, etc. directories and all associated subdirectories as well. If we rely on the fact that the generators are always in fixed location (this should be always true, right?), e.g. BAG_WORK_DIR/gen/gen/__init__.py, then we can add only those paths matching that pattern. Now it happens in a fraction of a second (as it should) and works from both the SDK and BAG.

Summary: this commit "forces" naming convention of the generators so that they can be used in the SyDeKick. Also, optimizations to performance. @mkosunen @vlahtin 
